### PR TITLE
Add dynamic TAG ID generation and hide form fields

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -92,33 +92,35 @@
                     </optgroup>
                 </select>
             </div>
+            <div id="extraFields" style="display:none;" class="row g-3">
             <div class="col-md-4">
                 <label class="form-label">Modelo</label>
-                <input type="text" class="form-control" id="modelo" required />
+                <input type="text" class="form-control" id="modelo" disabled required />
             </div>
             <div class="col-md-4">
                 <label class="form-label">Fabricante</label>
-                <input type="text" class="form-control" id="fabricante" required />
+                <input type="text" class="form-control" id="fabricante" disabled required />
             </div>
             <div class="col-md-4">
                 <label class="form-label">Tag ID</label>
-                <input type="text" class="form-control" id="tagid" placeholder="Digite o Tag ID BRACELL" required />
+                <input type="text" class="form-control" id="tagid" readonly disabled required />
             </div>
 
             <div class="col-md-4">
                 <label class="form-label">Serial</label>
                 <input type="text" class="form-control" id="serial" placeholder="Digite o serial do EQUIPAMENTO"
-                    required />
+                    disabled required />
             </div>
 
             <div class="col-md4">
                 <label for="form-label" for="foto">Foto do equipamento</label>
-                <input type="file" class="form-control" id="foto" name="foto" accept="image/*" required />
+                <input type="file" class="form-control" id="foto" name="foto" accept="image/*" disabled required />
             </div>
 
             <div class="col-12">
-                <button type="submit" class="btn btn-primary">Registrar Entrada</button>
+                <button type="submit" class="btn btn-primary" disabled>Registrar Entrada</button>
 
+            </div>
             </div>
 
         </form>
@@ -137,6 +139,19 @@
 
 
     <script>
+        const equipSelect = document.getElementById('equipamento');
+        const extraFields = document.getElementById('extraFields');
+        equipSelect.addEventListener('change', () => {
+            extraFields.style.display = '';
+            extraFields.querySelectorAll('input, button').forEach(el => el.disabled = false);
+            fetch(`https://equipamentcheck.onrender.com/next-tagid/${encodeURIComponent(equipSelect.value)}`)
+                .then(res => res.json())
+                .then(data => {
+                    document.getElementById('tagid').value = data.tagid;
+                })
+                .catch(err => console.error(err));
+        });
+
         document.getElementById('equipmentForm').addEventListener('submit', function (e) {
             e.preventDefault();
 

--- a/server.js
+++ b/server.js
@@ -29,6 +29,46 @@ const storage = multer.diskStorage({
 
 const upload = multer({ storage });
 
+const PREFIXES = {
+  Notebook: 'NB',
+  Desktop: 'DT',
+  Monitor: 'MN',
+  Impressora: 'IM',
+  Celular: 'CE',
+  Tablet: 'TB',
+  Teclado: 'TC',
+  Mouse: 'MS',
+  Webcam: 'WC',
+  'Fone de Ouvido': 'FO',
+  Carregador: 'CG',
+  'HD Externo': 'HE',
+  'Pen Drive': 'PD',
+  'Chave de fenda / Philips': 'CF',
+  Furadeira: 'FD',
+  Parafusadeira: 'PF',
+  'Serra Elétrica': 'SE',
+  Martelo: 'MA',
+  Alicate: 'AL',
+  Outros: 'OT',
+};
+
+app.get('/next-tagid/:equipamento', (req, res) => {
+  const equipamento = req.params.equipamento;
+  const prefix = PREFIXES[equipamento] || equipamento.slice(0, 2).toUpperCase();
+  const sql =
+    'SELECT tagid FROM equipamentos WHERE tagid LIKE ? ORDER BY id DESC LIMIT 1';
+  db.get(sql, [prefix + '%'], (err, row) => {
+    if (err) return res.status(500).json({ error: 'Erro ao consultar banco' });
+    let next = 1;
+    if (row && row.tagid) {
+      const n = parseInt(row.tagid.slice(prefix.length), 10);
+      if (!isNaN(n)) next = n + 1;
+    }
+    const tagid = prefix + String(next).padStart(3, '0');
+    res.json({ tagid });
+  });
+});
+
 // Registrar equipamento
 app.post("/equipamentos", upload.single("foto"), (req, res) => {
   const { nome, equipamento, modelo, fabricante, tagid, serial } = req.body;


### PR DESCRIPTION
## Summary
- show only responsible and equipment selection initially
- reveal remaining form fields after selecting equipment
- fetch next sequential TAG ID based on chosen equipment
- add `/next-tagid/:equipamento` API route for TAG ID generation

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686c684e86c8832dba4d43196d615576