### PR TITLE
Fix automatic tagid generation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -102,7 +102,7 @@
             </div>
             <div class="col-md-4">
                 <label class="form-label">Tag ID</label>
-                <input type="text" class="form-control" id="tagid" placeholder="Digite o Tag ID BRACELL" required />
+                <input type="text" class="form-control" id="tagid" placeholder="Deixe em branco para gerar automaticamente" />
             </div>
 
             <div class="col-md-4">
@@ -191,6 +191,7 @@
 
                     gerarQRCode(data.tagid);
                     document.getElementById('equipmentForm').reset();
+                    document.getElementById('tagid').value = data.tagid;
                 })
                 .catch((err) => {
                     Swal.fire({

--- a/server.js
+++ b/server.js
@@ -7,6 +7,10 @@ const multer = require("multer");
 const fs = require("fs");
 const app = express();
 
+function generateTagId() {
+  return `TAG${Date.now()}${Math.floor(Math.random() * 1000)}`;
+}
+
 app.use(cors());
 app.use(bodyParser.json());
 app.use(express.static("public"));
@@ -31,7 +35,10 @@ const upload = multer({ storage });
 
 // Registrar equipamento
 app.post("/equipamentos", upload.single("foto"), (req, res) => {
-  const { nome, equipamento, modelo, fabricante, tagid, serial } = req.body;
+  let { nome, equipamento, modelo, fabricante, tagid, serial } = req.body;
+  if (!tagid) {
+    tagid = generateTagId();
+  }
   const foto = req.file ? `/uploads/${req.file.filename}` : null;
   const dataEntrada = new Date().toISOString();
 


### PR DESCRIPTION
## Summary
- generate unique tag IDs on the server when none are provided
- allow leaving the Tag ID field empty on the form
- show generated Tag ID after successful registration

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686c70e14010832d87721838de435f7d